### PR TITLE
Fix dependency resolution

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ##### Core scientific packages
 matplotlib~=3.4.3
-numpy~=1.19.5
+numpy~=1.19
 pandas~=1.3.3
 scipy~=1.7.1
 


### PR DESCRIPTION
Fixes a dependency resolution bug in `requirements.txt` that prevents users (and Oryx) from installing requirements with `pip install -r requirements.txt`